### PR TITLE
Fix: delete tmp directory

### DIFF
--- a/yap.sh
+++ b/yap.sh
@@ -180,7 +180,7 @@ yap(){
     # invidious instance
     local invidious=https://yt.artemislena.eu
     # temporary files path
-    local tmp='/tmp/yap'
+    local tmp="/tmp/yap-$$"
     # max retry count
     local MAX_TRYS=3
 
@@ -404,7 +404,7 @@ yap(){
         rm "$output/$file_name.m4a.bak"
     fi
 
-    [ -f "$tmp" ] && rmdir "$tmp"
+    [ -d "$tmp" ] && rm -r "$tmp"
 
     if [[ "$play" != '' ]]; then
         echo -e "\nExecuting $play"


### PR DESCRIPTION
This solves the issue of the tmp directory not getting deleted.  
The previous code did not work because `[ -f "$tmp" ]` only checks for the existence of files, not directories. Furthermore `rmdir` only works with empty directories which is why we have to use `rm -r`.

I also changed the name of the tmp directory to contain the current pid so that two instances of `yap` don't interfere with each other.